### PR TITLE
Fix typo in MIDDLEWARE setting

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -36,7 +36,7 @@ of ``MIDDLEWARE``, so that each request can be set to use the correct schema.
 .. code-block:: python
 
     MIDDLEWARE = (
-        "django_pgschemas.middleware.TenantMainMiddleware",
+        "django_pgschemas.middleware.TenantMiddleware",
         # ...
     )
 


### PR DESCRIPTION
`"django_pgschemas.middleware.TenantMainMiddleware"` --> `"django_pgschemas.middleware.TenantMiddleware"`