### PR TITLE
Fallback domains

### DIFF
--- a/django_pgschemas/apps.py
+++ b/django_pgschemas/apps.py
@@ -27,6 +27,8 @@ class DjangoPGSchemasConfig(AppConfig):
             raise ImproperlyConfigured("TENANTS['public'] cannot contain a 'WS_URLCONF' key.")
         if "DOMAINS" in settings.TENANTS["public"]:
             raise ImproperlyConfigured("TENANTS['public'] cannot contain a 'DOMAINS' key.")
+        if "FALLBACK_DOMAINS" in settings.TENANTS["public"]:
+            raise ImproperlyConfigured("TENANTS['public'] cannot contain a 'FALLBACK_DOMAINS' key.")
 
     def _check_default_schemas(self):
         if not isinstance(settings.TENANTS.get("default"), dict):
@@ -35,6 +37,8 @@ class DjangoPGSchemasConfig(AppConfig):
             raise ImproperlyConfigured("TENANTS['default'] must contain a 'URLCONF' key.")
         if "DOMAINS" in settings.TENANTS["default"]:
             raise ImproperlyConfigured("TENANTS['default'] cannot contain a 'DOMAINS' key.")
+        if "FALLBACK_DOMAINS" in settings.TENANTS["default"]:
+            raise ImproperlyConfigured("TENANTS['default'] cannot contain a 'FALLBACK_DOMAINS' key.")
         if (
             "CLONE_REFERENCE" in settings.TENANTS["default"]
             and settings.TENANTS["default"]["CLONE_REFERENCE"] in settings.TENANTS

--- a/django_pgschemas/urlresolvers.py
+++ b/django_pgschemas/urlresolvers.py
@@ -116,9 +116,9 @@ def get_urlconf_from_schema(schema):
             if schema_name in ["public", "default"]:
                 continue
             if schema.domain_url in data["DOMAINS"]:
-                if "URLCONF" in data:
-                    return data["URLCONF"]
-                return None
+                return data["URLCONF"]
+            if schema.domain_url in data.get("FALLBACK_DOMAINS", []):
+                return data["URLCONF"]
         return None
 
     # Checking for dynamic tenants

--- a/dpgs_sandbox/settings.py
+++ b/dpgs_sandbox/settings.py
@@ -38,6 +38,7 @@ TENANTS = {
         "URLCONF": "app_main.urls",
         "WS_URLCONF": "app_main.ws_urls",
         "DOMAINS": ["test.com"],
+        "FALLBACK_DOMAINS": ["everyone.test.com"],
     },
     "blog": {
         "APPS": ["shared_common", "app_blog", "django.contrib.sessions"],

--- a/dpgs_sandbox/tests/test_apps.py
+++ b/dpgs_sandbox/tests/test_apps.py
@@ -91,6 +91,11 @@ class AppConfigTestCase(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             self.app_config._check_default_schemas()
 
+    @override_settings(TENANTS={"default": {**settings_default, "FALLBACK_DOMAINS": ""}})
+    def test_fallback_domains_on_default(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.app_config._check_default_schemas()
+
     def test_repeated_clone_reference(self):
         with override_settings(TENANTS={"public": {}, "default": {**settings_default, "CLONE_REFERENCE": "public"}}):
             with self.assertRaises(ImproperlyConfigured):

--- a/dpgs_sandbox/tests/test_apps.py
+++ b/dpgs_sandbox/tests/test_apps.py
@@ -66,6 +66,11 @@ class AppConfigTestCase(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             self.app_config._check_public_schema()
 
+    @override_settings(TENANTS={"public": {**settings_public, "FALLBACK_DOMAINS": ""}})
+    def test_fallback_domains_on_public(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.app_config._check_public_schema()
+
     @override_settings(TENANTS=settings_public)
     def test_no_default(self):
         with self.assertRaises(ImproperlyConfigured):


### PR DESCRIPTION
Added `FALLBACK_DOMAINS` configuration, the only way to route a main site and tenant sites through a single domain. Consider this:

| Domain | Tenant | Type |
| - | - | - |
| `mydomain.com` | main tenant | static |
| `mydomain.com/client1` | client 1 | dynamic |
| `mydomain.com/client2` | client 2 | dynamic |

Since we always search first in the static tenants, any url that begins with `mydomain.com` will be routed against the main tenant without ever checking the dynamic tenants. Then, we cannot use the domain in the main tenant.

Fallback domains would be the workaround. They will be checked after all dynamic tenants have been checked, a third step in the domain matching.

To make the example work, the main tenant would have `TENANTS["main"]["DOMAINS"] = []` and then `TENANTS["main"]["FALLBACK_DOMAINS"] = ["mydomain.com"]`