### PR TITLE
Change in TENANTS dict regarding TENANT_MODEL and DOMAIN_MODEL

### DIFF
--- a/django_pgschemas/apps.py
+++ b/django_pgschemas/apps.py
@@ -17,10 +17,6 @@ class DjangoPGSchemasConfig(AppConfig):
     def _check_public_schema(self):
         if not isinstance(settings.TENANTS.get("public"), dict):
             raise ImproperlyConfigured("TENANTS must contain a 'public' dict.")
-        if "TENANT_MODEL" not in settings.TENANTS["public"]:
-            raise ImproperlyConfigured("TENANTS['public'] must contain a 'TENANT_MODEL' key.")
-        if "DOMAIN_MODEL" not in settings.TENANTS["public"]:
-            raise ImproperlyConfigured("TENANTS['public'] must contain a 'DOMAIN_MODEL' key.")
         if "URLCONF" in settings.TENANTS["public"]:
             raise ImproperlyConfigured("TENANTS['public'] cannot contain a 'URLCONF' key.")
         if "WS_URLCONF" in settings.TENANTS["public"]:
@@ -33,6 +29,10 @@ class DjangoPGSchemasConfig(AppConfig):
     def _check_default_schemas(self):
         if not isinstance(settings.TENANTS.get("default"), dict):
             raise ImproperlyConfigured("TENANTS must contain a 'default' dict.")
+        if "TENANT_MODEL" not in settings.TENANTS["default"]:
+            raise ImproperlyConfigured("TENANTS['default'] must contain a 'TENANT_MODEL' key.")
+        if "DOMAIN_MODEL" not in settings.TENANTS["default"]:
+            raise ImproperlyConfigured("TENANTS['default'] must contain a 'DOMAIN_MODEL' key.")
         if "URLCONF" not in settings.TENANTS["default"]:
             raise ImproperlyConfigured("TENANTS['default'] must contain a 'URLCONF' key.")
         if "DOMAINS" in settings.TENANTS["default"]:
@@ -43,7 +43,7 @@ class DjangoPGSchemasConfig(AppConfig):
             "CLONE_REFERENCE" in settings.TENANTS["default"]
             and settings.TENANTS["default"]["CLONE_REFERENCE"] in settings.TENANTS
         ):
-            raise ImproperlyConfigured("TENANTS['default']['CLONE_REFERENCE'] must be a unique schema name")
+            raise ImproperlyConfigured("TENANTS['default']['CLONE_REFERENCE'] must be a unique schema name.")
 
     def _check_overall_schemas(self):
         for schema in settings.TENANTS:

--- a/django_pgschemas/models.py
+++ b/django_pgschemas/models.py
@@ -103,7 +103,7 @@ class DomainMixin(models.Model):
     """
 
     tenant = models.ForeignKey(
-        settings.TENANTS["public"]["TENANT_MODEL"], db_index=True, related_name="domains", on_delete=models.CASCADE
+        settings.TENANTS["default"]["TENANT_MODEL"], db_index=True, related_name="domains", on_delete=models.CASCADE
     )
 
     domain = models.CharField(max_length=253, db_index=True)

--- a/django_pgschemas/utils.py
+++ b/django_pgschemas/utils.py
@@ -9,12 +9,12 @@ from django.db import connection, transaction, ProgrammingError, DEFAULT_DB_ALIA
 
 def get_tenant_model(require_ready=True):
     "Returns the tenant model."
-    return apps.get_model(settings.TENANTS["public"]["TENANT_MODEL"], require_ready=require_ready)
+    return apps.get_model(settings.TENANTS["default"]["TENANT_MODEL"], require_ready=require_ready)
 
 
 def get_domain_model(require_ready=True):
     "Returns the domain model."
-    return apps.get_model(settings.TENANTS["public"]["DOMAIN_MODEL"], require_ready=require_ready)
+    return apps.get_model(settings.TENANTS["default"]["DOMAIN_MODEL"], require_ready=require_ready)
 
 
 def get_tenant_database_alias():

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -4,7 +4,7 @@ Advanced configuration
 Fast dynamic tenant creation
 ----------------------------
 
-Every time a instance of ``settings.TENANTS["public"]["TENANT_MODEL"]`` is
+Every time a instance of ``settings.TENANTS["default"]["TENANT_MODEL"]`` is
 created, by default, the corresponding schema is created and synchronized
 automatically. Depending on the number of migrations you already have in place,
 or the amount of time these could take, or whether you need to pre-populate the
@@ -95,8 +95,6 @@ Something like this would be the proper configuration for the present case:
                 "shared_app",
                 # ...
             ],
-            "TENANT_MODEL": "shared_app.Client",
-            "DOMAIN_MODEL": "shared_app.Domain",
         },
         "main": {
             "APPS": [
@@ -110,6 +108,8 @@ Something like this would be the proper configuration for the present case:
             "URLCONF": "main_app.urls",
         },
         "default": {
+            "TENANT_MODEL": "shared_app.Client",
+            "DOMAIN_MODEL": "shared_app.Domain",
             "APPS": [
                 "django.contrib.auth",
                 "django.contrib.sessions",
@@ -252,7 +252,7 @@ The base commands are:
     ``django_pgschemas.schema.SchemaDescriptor``. Make sure you do the
     appropriate type checking before accessing the tenant members, as not every
     tenant will be an instance of
-    ``settings.TENANTS["public"]["TENANT_MODEL"]``.
+    ``settings.TENANTS["default"]["TENANT_MODEL"]``.
 
 Caching
 -------

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -65,11 +65,11 @@ Add the minimal tenant configuration.
                 "shared_app",
                 # ...
             ],
-            "TENANT_MODEL": "shared_app.Client",
-            "DOMAIN_MODEL": "shared_app.Domain",
         },
         # ...
         "default": {
+            "TENANT_MODEL": "shared_app.Client",
+            "DOMAIN_MODEL": "shared_app.Domain",
             "APPS": [
                 "django.contrib.auth",
                 "django.contrib.sessions",
@@ -138,8 +138,8 @@ More static tenants can be added and routed.
     }
 
 Dynamic tenants need to be created through instances of
-``TENANTS["public"]["TENANT_MODEL"]`` and routed through instances of
-``TENANTS["public"]["DOMAIN_MODEL"]``.
+``TENANTS["default"]["TENANT_MODEL"]`` and routed through instances of
+``TENANTS["default"]["DOMAIN_MODEL"]``.
 
 .. code-block:: python
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -21,8 +21,6 @@ A sample tenant configuration is:
                 "shared_app",
                 # ...
             ],
-            "TENANT_MODEL": "shared_app.Client",
-            "DOMAIN_MODEL": "shared_app.Domain",
         },
         "www": {
             "APPS": [
@@ -45,6 +43,8 @@ A sample tenant configuration is:
             "URLCONF": "blog_app.urls",
         },
         "default": {
+            "TENANT_MODEL": "shared_app.Client",
+            "DOMAIN_MODEL": "shared_app.Domain",
             "APPS": [
                 "django.contrib.auth",
                 "django.contrib.sessions",

--- a/dpgs_sandbox/settings.py
+++ b/dpgs_sandbox/settings.py
@@ -30,8 +30,6 @@ ALLOWED_HOSTS = [".test.com"]
 TENANTS = {
     "public": {
         "APPS": ["shared_public", "django.contrib.auth", "django.contrib.contenttypes", "django.contrib.staticfiles"],
-        "TENANT_MODEL": "shared_public.Tenant",
-        "DOMAIN_MODEL": "shared_public.Domain",
     },
     "www": {
         "APPS": ["shared_common", "app_main", "django.contrib.sessions"],
@@ -46,6 +44,8 @@ TENANTS = {
         "DOMAINS": ["blog.test.com"],
     },
     "default": {
+        "TENANT_MODEL": "shared_public.Tenant",
+        "DOMAIN_MODEL": "shared_public.Domain",
         "APPS": ["shared_common", "app_tenants", "django.contrib.sessions"],
         "URLCONF": "app_tenants.urls",
         "WS_URLCONF": "app_tenants.ws_urls",

--- a/dpgs_sandbox/tests/test_apps.py
+++ b/dpgs_sandbox/tests/test_apps.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 
-settings_public = {"TENANT_MODEL": "shared_public.Tenant", "DOMAIN_MODEL": "shared_public.Domain"}
-settings_default = {"URLCONF": ""}
+BASE_DEFAULT = {"TENANT_MODEL": "shared_public.Tenant", "DOMAIN_MODEL": "shared_public.Domain", "URLCONF": ""}
 
 
 class AppConfigTestCase(TestCase):
@@ -18,138 +17,167 @@ class AppConfigTestCase(TestCase):
     @override_settings()
     def test_missing_tenants(self):
         del settings.TENANTS
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_tenant_dict()
+        self.assertEqual(str(ctx.exception), "TENANTS dict setting not set.")
 
     @override_settings(TENANTS=list)
     def test_wrong_type_tenants(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_tenant_dict()
+        self.assertEqual(str(ctx.exception), "TENANTS dict setting not set.")
 
     @override_settings(TENANTS={})
     def test_no_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'public' dict.")
 
     @override_settings(TENANTS={"public": None})
     def test_wrong_type_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'public' dict.")
 
     @override_settings(TENANTS={"public": 4})
     def test_other_type_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'public' dict.")
 
-    @override_settings(TENANTS={"public": {"DOMAIN_MODEL": ""}})
-    def test_no_tenant_model_public(self):
-        with self.assertRaises(ImproperlyConfigured):
-            self.app_config._check_public_schema()
-
-    @override_settings(TENANTS={"public": {"TENANT_MODEL": ""}})
-    def test_no_domain_model_public(self):
-        with self.assertRaises(ImproperlyConfigured):
-            self.app_config._check_public_schema()
-
-    @override_settings(TENANTS={"public": {**settings_public, "URLCONF": ""}})
+    @override_settings(TENANTS={"public": {"URLCONF": ""}})
     def test_urlconf_on_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS['public'] cannot contain a 'URLCONF' key.")
 
-    @override_settings(TENANTS={"public": {**settings_public, "WS_URLCONF": ""}})
+    @override_settings(TENANTS={"public": {"WS_URLCONF": ""}})
     def test_wsurlconf_on_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS['public'] cannot contain a 'WS_URLCONF' key.")
 
-    @override_settings(TENANTS={"public": {**settings_public, "DOMAINS": ""}})
+    @override_settings(TENANTS={"public": {"DOMAINS": ""}})
     def test_domains_on_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS['public'] cannot contain a 'DOMAINS' key.")
 
-    @override_settings(TENANTS={"public": {**settings_public, "FALLBACK_DOMAINS": ""}})
+    @override_settings(TENANTS={"public": {"FALLBACK_DOMAINS": ""}})
     def test_fallback_domains_on_public(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_public_schema()
+        self.assertEqual(str(ctx.exception), "TENANTS['public'] cannot contain a 'FALLBACK_DOMAINS' key.")
 
-    @override_settings(TENANTS=settings_public)
+    @override_settings(TENANTS={})
     def test_no_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'default' dict.")
 
     @override_settings(TENANTS={"default": None})
     def test_wrong_type_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'default' dict.")
 
     @override_settings(TENANTS={"default": "wawa"})
     def test_other_type_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS must contain a 'default' dict.")
 
-    @override_settings(TENANTS={"default": {}})
+    @override_settings(TENANTS={"default": {"DOMAIN_MODEL": ""}})
+    def test_no_tenant_model_default(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['default'] must contain a 'TENANT_MODEL' key.")
+
+    @override_settings(TENANTS={"default": {"TENANT_MODEL": ""}})
+    def test_no_domain_model_default(self):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
+            self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['default'] must contain a 'DOMAIN_MODEL' key.")
+
+    @override_settings(TENANTS={"default": {"TENANT_MODEL": None, "DOMAIN_MODEL": None}})
     def test_no_urlconf_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['default'] must contain a 'URLCONF' key.")
 
-    @override_settings(TENANTS={"default": {**settings_default, "DOMAINS": ""}})
+    @override_settings(TENANTS={"default": {**BASE_DEFAULT, "DOMAINS": ""}})
     def test_domains_on_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['default'] cannot contain a 'DOMAINS' key.")
 
-    @override_settings(TENANTS={"default": {**settings_default, "FALLBACK_DOMAINS": ""}})
+    @override_settings(TENANTS={"default": {**BASE_DEFAULT, "FALLBACK_DOMAINS": ""}})
     def test_fallback_domains_on_default(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_default_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['default'] cannot contain a 'FALLBACK_DOMAINS' key.")
 
     def test_repeated_clone_reference(self):
-        with override_settings(TENANTS={"public": {}, "default": {**settings_default, "CLONE_REFERENCE": "public"}}):
-            with self.assertRaises(ImproperlyConfigured):
+        with override_settings(TENANTS={"public": {}, "default": {**BASE_DEFAULT, "CLONE_REFERENCE": "public"}}):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_default_schemas()
-        with override_settings(TENANTS={"default": {**settings_default, "CLONE_REFERENCE": "default"}}):
-            with self.assertRaises(ImproperlyConfigured):
+            self.assertEqual(str(ctx.exception), "TENANTS['default']['CLONE_REFERENCE'] must be a unique schema name.")
+        with override_settings(TENANTS={"default": {**BASE_DEFAULT, "CLONE_REFERENCE": "default"}}):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_default_schemas()
+            self.assertEqual(str(ctx.exception), "TENANTS['default']['CLONE_REFERENCE'] must be a unique schema name.")
 
     def test_valid_schema_name(self):
         with override_settings(TENANTS={"pg_whatever": {}}):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_overall_schemas()
+            self.assertEqual(str(ctx.exception), "'pg_whatever' is not a valid schema name.")
         with override_settings(TENANTS={"&$&*": {}}):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_overall_schemas()
+            self.assertEqual(str(ctx.exception), "'&$&*' is not a valid schema name.")
 
     @override_settings(TENANTS={"www": {}})
     def test_domains_on_others(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_overall_schemas()
+        self.assertEqual(str(ctx.exception), "TENANTS['www'] must contain a 'DOMAINS' list.")
 
     @override_settings(DATABASE_ROUTERS=())
     def test_database_routers(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ImproperlyConfigured) as ctx:
             self.app_config._check_complementary_settings()
+        self.assertEqual(
+            str(ctx.exception), "DATABASE_ROUTERS setting must contain 'django_pgschemas.routers.SyncRouter'."
+        )
 
     def test_extra_search_paths(self):
         with override_settings(
-            TENANTS={"public": settings_public, "default": {}, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["public"]
+            TENANTS={"public": {}, "default": BASE_DEFAULT, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["public"]
         ):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_extra_search_paths()
+            self.assertEqual(str(ctx.exception), "Do not include 'public' on PGSCHEMAS_EXTRA_SEARCH_PATHS.")
         with override_settings(
-            TENANTS={"public": settings_public, "default": {}, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["default"]
+            TENANTS={"public": {}, "default": BASE_DEFAULT, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["default"]
         ):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_extra_search_paths()
+            self.assertEqual(str(ctx.exception), "Do not include 'default' on PGSCHEMAS_EXTRA_SEARCH_PATHS.")
         with override_settings(
-            TENANTS={"public": settings_public, "default": {}, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["www"]
+            TENANTS={"public": {}, "default": BASE_DEFAULT, "www": {}}, PGSCHEMAS_EXTRA_SEARCH_PATHS=["www"]
         ):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_extra_search_paths()
+            self.assertEqual(str(ctx.exception), "Do not include 'www' on PGSCHEMAS_EXTRA_SEARCH_PATHS.")
         with override_settings(
-            TENANTS={"public": settings_public, "default": {"CLONE_REFERENCE": "sample"}, "www": {}},
+            TENANTS={"public": {}, "default": {**BASE_DEFAULT, "CLONE_REFERENCE": "sample"}, "www": {}},
             PGSCHEMAS_EXTRA_SEARCH_PATHS=["sample"],
         ):
-            with self.assertRaises(ImproperlyConfigured):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
                 self.app_config._check_extra_search_paths()
+            self.assertEqual(str(ctx.exception), "Do not include 'sample' on PGSCHEMAS_EXTRA_SEARCH_PATHS.")
 
-    @override_settings(TENANTS={"public": settings_public, "default": settings_default})
+    @override_settings(TENANTS={"public": {}, "default": BASE_DEFAULT})
     def test_all_good_here(self):
         self.app_config.ready()

--- a/dpgs_sandbox/tests/test_checks.py
+++ b/dpgs_sandbox/tests/test_checks.py
@@ -8,7 +8,7 @@ from django_pgschemas.checks import check_principal_apps, check_other_apps, chec
 
 
 TenantModel = get_tenant_model()
-BASE_PUBLIC = {"TENANT_MODEL": "shared_public.Tenant", "DOMAIN_MODEL": "shared_public.DOMAIN"}
+BASE_DEFAULT = {"TENANT_MODEL": "shared_public.Tenant", "DOMAIN_MODEL": "shared_public.DOMAIN"}
 
 
 class AppChecksTestCase(TestCase):
@@ -20,7 +20,7 @@ class AppChecksTestCase(TestCase):
         self.app_config = apps.get_app_config("django_pgschemas")
 
     def test_core_apps_location(self):
-        with override_settings(TENANTS={"public": {"APPS": [], **BASE_PUBLIC}}):
+        with override_settings(TENANTS={"public": {"APPS": []}, "default": BASE_DEFAULT}):
             errors = check_principal_apps(self.app_config)
             expected_errors = [
                 checks.Error("Your tenant app 'shared_public' must be on the 'public' schema.", id="pgschemas.W001"),
@@ -28,7 +28,7 @@ class AppChecksTestCase(TestCase):
             ]
             self.assertEqual(errors, expected_errors)
         with override_settings(
-            TENANTS={"public": {"APPS": ["shared_public"], **BASE_PUBLIC}, "default": {"APPS": ["shared_public"]}}
+            TENANTS={"public": {"APPS": ["shared_public"]}, "default": {**BASE_DEFAULT, "APPS": ["shared_public"]}}
         ):
             errors = check_principal_apps(self.app_config)
             expected_errors = [


### PR DESCRIPTION
In preparation for static domains only, I decided to move `TENANT_MODEL` and `DOMAIN_MODEL` from `public` to `default`. The idea is to be able to supress the `default` entry in the `TENANTS` dict without further changes.