### PR TITLE
Schema handler as asgiref.local

### DIFF
--- a/django_pgschemas/__init__.py
+++ b/django_pgschemas/__init__.py
@@ -1,1 +1,3 @@
+from .schema import schema_handler
+
 default_app_config = "django_pgschemas.apps.DjangoPGSchemasConfig"

--- a/django_pgschemas/contrib/cache.py
+++ b/django_pgschemas/contrib/cache.py
@@ -1,4 +1,4 @@
-from django.db import connection
+from ..schema import schema_handler
 
 
 def make_key(key, key_prefix, version):
@@ -8,7 +8,7 @@ def make_key(key, key_prefix, version):
     Constructs the key used by all other methods. Prepends the tenant
     `schema_name` and `key_prefix'.
     """
-    return "%s:%s:%s:%s" % (connection.schema.schema_name, key_prefix, version, key)
+    return "%s:%s:%s:%s" % (schema_handler.active.schema_name, key_prefix, version, key)
 
 
 def reverse_key(key):

--- a/django_pgschemas/contrib/files/storage.py
+++ b/django_pgschemas/contrib/files/storage.py
@@ -2,7 +2,8 @@ import os
 
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
-from django.db import connection
+
+from ...schema import schema_handler
 
 
 class TenantFileSystemStorage(FileSystemStorage):
@@ -12,13 +13,13 @@ class TenantFileSystemStorage(FileSystemStorage):
     """
 
     def get_schema_path_identifier(self):
-        if not connection.schema:
+        if not schema_handler.active:
             return ""
-        path_identifier = connection.schema.schema_name
-        if hasattr(connection.schema, "schema_pathname"):
-            path_identifier = connection.schema.schema_pathname()
+        path_identifier = schema_handler.active.schema_name
+        if hasattr(schema_handler.active, "schema_pathname"):
+            path_identifier = schema_handler.active.schema_pathname()
         elif hasattr(settings, "PGSCHEMAS_PATHNAME_FUNCTION"):
-            path_identifier = settings.PGSCHEMAS_PATHNAME_FUNCTION(connection.schema)
+            path_identifier = settings.PGSCHEMAS_PATHNAME_FUNCTION(schema_handler.active)
         return path_identifier
 
     @property  # To avoid caching of tenant
@@ -44,7 +45,7 @@ class TenantFileSystemStorage(FileSystemStorage):
         appended.
         """
         url_folder = self.get_schema_path_identifier()
-        if url_folder and connection.schema and connection.schema.folder:
+        if url_folder and schema_handler.active and schema_handler.active.folder:
             # Since we're already prepending all URLs with schema, there is no
             # need to make the differentiation here
             url_folder = ""

--- a/django_pgschemas/log.py
+++ b/django_pgschemas/log.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import connection
+from .schema import schema_handler
 
 
 class SchemaContextFilter(logging.Filter):
@@ -9,6 +9,6 @@ class SchemaContextFilter(logging.Filter):
     """
 
     def filter(self, record):
-        record.schema_name = connection.schema.schema_name
-        record.domain_url = connection.schema.domain_url
+        record.schema_name = schema_handler.active.schema_name
+        record.domain_url = schema_handler.active.domain_url
         return True

--- a/django_pgschemas/management/commands/_executors.py
+++ b/django_pgschemas/management/commands/_executors.py
@@ -6,6 +6,8 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, OutputWrapper
 from django.db import connection, connections, transaction
 
+from ...schema import schema_handler
+
 
 def run_on_schema(
     schema_name,
@@ -52,7 +54,7 @@ def run_on_schema(
 
     if fork_db:
         connections.close_all()
-    connection.set_schema_to(schema_name)
+    schema_handler.set_schema_to(schema_name)
 
     if pass_schema_in_kwargs:
         kwargs.update({"schema_name": schema_name})

--- a/django_pgschemas/middleware.py
+++ b/django_pgschemas/middleware.py
@@ -1,11 +1,10 @@
 import re
 
 from django.conf import settings
-from django.db import connection
 from django.http import Http404
 from django.urls import clear_url_caches, set_urlconf
 
-from .schema import SchemaDescriptor
+from .schema import SchemaDescriptor, schema_handler
 from .urlresolvers import get_urlconf_from_schema
 from .utils import get_domain_model, remove_www
 
@@ -24,7 +23,7 @@ class TenantMiddleware:
 
     def __call__(self, request):
         hostname = remove_www(request.get_host().split(":")[0])
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
 
         tenant = None
 
@@ -74,5 +73,5 @@ class TenantMiddleware:
         urlconf = get_urlconf_from_schema(tenant)
         request.urlconf = urlconf
         set_urlconf(urlconf)
-        connection.set_schema(tenant)
+        schema_handler.set_schema(tenant)
         return self.get_response(request)

--- a/django_pgschemas/postgresql_backend/_constraints.py
+++ b/django_pgschemas/postgresql_backend/_constraints.py
@@ -1,5 +1,7 @@
 from django.db.models.indexes import Index
 
+from ..schema import schema_handler
+
 
 def get_constraints(self, cursor, table_name):
     """
@@ -38,7 +40,7 @@ def get_constraints(self, cursor, table_name):
         JOIN pg_namespace AS ns ON cl.relnamespace = ns.oid
         WHERE ns.nspname = %s AND cl.relname = %s
     """,
-        [self.connection.schema.schema_name, table_name],
+        [schema_handler.active.schema_name, table_name],
     )
     for constraint, columns, kind, used_cols, options in cursor.fetchall():
         constraints[constraint] = {
@@ -89,7 +91,7 @@ def get_constraints(self, cursor, table_name):
         ) s2
         GROUP BY indexname, indisunique, indisprimary, amname, exprdef, attoptions;
     """,
-        [table_name, self.connection.schema.schema_name],
+        [table_name, schema_handler.active.schema_name],
     )
     for index, columns, unique, primary, orders, type_, definition, options in cursor.fetchall():
         if index not in constraints:

--- a/django_pgschemas/postgresql_backend/introspection.py
+++ b/django_pgschemas/postgresql_backend/introspection.py
@@ -3,6 +3,7 @@ from django.db.backends.postgresql.introspection import DatabaseIntrospection
 from django.utils.encoding import force_text
 
 from . import _constraints
+from ..schema import schema_handler
 
 
 class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
@@ -33,7 +34,7 @@ class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
             WHERE c.relkind IN ('r', 'v', '')
                 AND n.nspname = '%s'
                 AND pg_catalog.pg_table_is_visible(c.oid)"""
-            % self.connection.schema.schema_name
+            % schema_handler.active.schema_name
         )
 
         return [
@@ -51,7 +52,7 @@ class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
             SELECT column_name, is_nullable, column_default
             FROM information_schema.columns
             WHERE table_schema = %s and table_name = %s""",
-            [self.connection.schema.schema_name, table_name],
+            [schema_handler.active.schema_name, table_name],
         )
         field_map = {line[0]: line[1:] for line in cursor.fetchall()}
         cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
@@ -69,7 +70,7 @@ class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
     def get_indexes(self, cursor, table_name):
         # This query retrieves each index on the given table, including the
         # first associated field name
-        cursor.execute(self._get_indexes_query, [table_name, self.connection.schema.schema_name])
+        cursor.execute(self._get_indexes_query, [table_name, schema_handler.active.schema_name])
         indexes = {}
         for row in cursor.fetchall():
             # row[1] (idx.indkey) is stored in the DB as an array. It comes out as
@@ -103,7 +104,7 @@ class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
             LEFT JOIN pg_attribute a2 ON c2.oid = a2.attrelid AND a2.attnum = con.confkey[1]
             WHERE c1.relname = %s and n.nspname = %s
                 AND con.contype = 'f'""",
-            [table_name, self.connection.schema.schema_name],
+            [table_name, schema_handler.active.schema_name],
         )
         relations = {}
         for row in cursor.fetchall():
@@ -128,7 +129,7 @@ class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover
                     AND ccu.constraint_name = tc.constraint_name
             WHERE kcu.table_name = %s AND tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = %s
         """,
-            [table_name, self.connection.schema.schema_name],
+            [table_name, schema_handler.active.schema_name],
         )
         key_columns.extend(cursor.fetchall())
         return key_columns

--- a/django_pgschemas/postgresql_backend/introspection.py
+++ b/django_pgschemas/postgresql_backend/introspection.py
@@ -2,8 +2,8 @@ from django.db.backends.base.introspection import FieldInfo, TableInfo
 from django.db.backends.postgresql.introspection import DatabaseIntrospection
 from django.utils.encoding import force_text
 
-from . import _constraints
 from ..schema import schema_handler
+from . import _constraints
 
 
 class DatabaseSchemaIntrospection(DatabaseIntrospection):  # pragma: no cover

--- a/django_pgschemas/routers.py
+++ b/django_pgschemas/routers.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.conf import settings
-from django.db import connection
 
+from .schema import schema_handler
 from .utils import get_tenant_database_alias
 
 
@@ -16,13 +16,13 @@ class SyncRouter(object):
         return (app_config.name in app_list) or (app_config_full_name in app_list)
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        if db != get_tenant_database_alias() or not hasattr(connection, "schema"):
+        if db != get_tenant_database_alias() or not schema_handler.active:
             return False
         app_list = []
-        if connection.schema.schema_name == "public":
+        if schema_handler.active.schema_name == "public":
             app_list = settings.TENANTS["public"]["APPS"]
-        elif connection.schema.schema_name in settings.TENANTS:
-            app_list = settings.TENANTS[connection.schema.schema_name]["APPS"]
+        elif schema_handler.active.schema_name in settings.TENANTS:
+            app_list = settings.TENANTS[schema_handler.active.schema_name]["APPS"]
         else:
             app_list = settings.TENANTS["default"]["APPS"]
         if not app_list:

--- a/django_pgschemas/schema.py
+++ b/django_pgschemas/schema.py
@@ -1,7 +1,6 @@
-from threading import local
+from asgiref.local import Local
 
-
-_active = local()
+_active = Local()
 
 
 class ActiveSchemaHandler:

--- a/django_pgschemas/test/cases.py
+++ b/django_pgschemas/test/cases.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from django.core.management import call_command
-from django.db import connection
 from django.test import TestCase
 
+from ..schema import schema_handler
 from ..utils import get_domain_model, get_tenant_model
 
 ALLOWED_TEST_DOMAIN = ".test.com"
@@ -44,7 +44,7 @@ class TenantTestCase(TestCase):
         cls.domain = get_domain_model()(tenant=cls.tenant, domain=tenant_domain)
         cls.setup_domain(cls.domain)
         cls.domain.save()
-        connection.set_schema(cls.tenant)
+        schema_handler.set_schema(cls.tenant)
         cls.cls_atomics = cls._enter_atomics()
         try:
             cls.setUpTestData()
@@ -55,7 +55,7 @@ class TenantTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
         cls.domain.delete()
         cls.tenant.delete(force_drop=True)
         cls.remove_allowed_test_domain()
@@ -134,14 +134,14 @@ class FastTenantTestCase(TenantTestCase):
         else:
             cls.setup_test_tenant_and_domain()
 
-        connection.set_schema(cls.tenant)
+        schema_handler.set_schema(cls.tenant)
 
     @classmethod
     def tearDownClass(cls):
         TenantModel = get_tenant_model()
         test_schema_name = cls.get_test_schema_name()
         TenantModel.objects.filter(schema_name=test_schema_name).delete()
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
 
     def _fixture_teardown(self):
         if self.flush_data():

--- a/django_pgschemas/urlresolvers.py
+++ b/django_pgschemas/urlresolvers.py
@@ -2,10 +2,9 @@ import re
 import sys
 
 from django.conf import settings
-from django.db import connection
 from django.urls import URLResolver
 
-from .schema import SchemaDescriptor
+from .schema import SchemaDescriptor, schema_handler
 from .utils import get_domain_model
 
 
@@ -17,7 +16,7 @@ class TenantPrefixPattern:
         DomainModel = get_domain_model()
         try:
             domain = DomainModel.objects.exclude(folder="").get(
-                tenant__schema_name=connection.schema.schema_name, domain=connection.schema.domain_url
+                tenant__schema_name=schema_handler.active.schema_name, domain=schema_handler.active.domain_url
             )
             return "{}/".format(domain.folder)
         except DomainModel.DoesNotExist:

--- a/dpgs_sandbox/tests/test_tenants.py
+++ b/dpgs_sandbox/tests/test_tenants.py
@@ -4,11 +4,10 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.management import call_command
-from django.db import ProgrammingError, connection, transaction
-from django.dispatch import receiver
+from django.db import ProgrammingError, transaction
 from django.test import TestCase, TransactionTestCase
 
-from django_pgschemas.schema import SchemaDescriptor
+from django_pgschemas.schema import SchemaDescriptor, schema_handler
 from django_pgschemas.signals import schema_post_sync
 from django_pgschemas.utils import drop_schema, get_domain_model, get_tenant_model, schema_exists
 
@@ -114,7 +113,7 @@ class TenantTestCase(TestCase):
             user.set_password("weakpassword")
             user.save()
             TenantData.objects.create(user=user, catalog=catalog)
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
         super().setUpClass()
 
     @classmethod

--- a/dpgs_sandbox/tests/test_urlresolvers.py
+++ b/dpgs_sandbox/tests/test_urlresolvers.py
@@ -1,12 +1,11 @@
 import sys
 from importlib import import_module
 
-from django.db import connection
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from django_pgschemas.middleware import TenantMiddleware
-from django_pgschemas.schema import SchemaDescriptor
+from django_pgschemas.schema import SchemaDescriptor, schema_handler
 from django_pgschemas.urlresolvers import TenantPrefixPattern, get_urlconf_from_schema
 from django_pgschemas.utils import get_domain_model, get_tenant_model
 
@@ -48,7 +47,7 @@ class URLResolversTestCase(TestCase):
             tenant.save(verbosity=0)
             DomainModel.objects.create(tenant=tenant, domain="{}.test.com".format(schema_name))
             DomainModel.objects.create(tenant=tenant, domain="everyone.test.com", folder=schema_name)  # primary
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
         super().setUpClass()
 
     @classmethod
@@ -99,7 +98,7 @@ class URLConfFactoryTestCase(TestCase):
         tenant.save(verbosity=0)
         DomainModel.objects.create(tenant=tenant, domain="{}.test.com".format(schema_name))
         DomainModel.objects.create(tenant=tenant, domain="everyone.test.com", folder=schema_name)  # primary
-        connection.set_schema_to_public()
+        schema_handler.set_schema_to_public()
         super().setUpClass()
 
     @classmethod


### PR DESCRIPTION
Looking for integrated options for sharding schemas across databases. In order to do that, it's no longer feasible to keep storing the active schema in the `django.db.connection`, as it sometimes gets lost when using a different database than default.

Contributes towards #40 