### PR TITLE
Improve clone schema

### DIFF
--- a/django_pgschemas/utils.py
+++ b/django_pgschemas/utils.py
@@ -278,7 +278,7 @@ FOR record IN
     IF include_recs
       THEN
       -- Insert records from source table
-      EXECUTE 'INSERT INTO ' || buffer || ' SELECT * FROM "' || source_schema || '".' || quote_ident(object) || ';';
+      EXECUTE 'INSERT INTO ' || buffer || ' OVERRIDING SYSTEM VALUE SELECT * FROM "' || source_schema || '".' || quote_ident(object) || ';';
     END IF;
 
     FOR column_, default_ IN


### PR DESCRIPTION
Fix cloning GENERATED ALWAYS columns issue.

When cloning schemas with GENERATED ALWAYS column, for example, `id` Postgres raises an error:

```
"ERROR:  cannot insert into column "id"
DETAIL:  Column "id" is an identity column defined as GENERATED ALWAYS.
HINT:  Use OVERRIDING SYSTEM VALUE to override.

```