### PR TITLE
Don’t try to set tenant in middleware if it is already set.

### DIFF
--- a/django_pgschemas/middleware.py
+++ b/django_pgschemas/middleware.py
@@ -27,6 +27,9 @@ def TenantMiddleware(get_response):
     """
 
     def logic(request):
+        if hasattr(request, "tenant"):
+            return
+
         hostname = remove_www(request.get_host().split(":")[0])
 
         activate_public()


### PR DESCRIPTION
In my application, I have another middleware that sets the tenant based on a header if present. This change is necessary to prevent overriding the previous middleware.